### PR TITLE
fix: breakpoints not stopping when debugging .ts tests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -66,6 +66,7 @@ const createTransformer = (userOptions: UserOptions = {}): Transformer<UserOptio
       const result = transformSync(source, {
         ...options,
         ...config.globals['jest-esbuild'] as UserOptions,
+        sourcefile: path,
         loader: userOptions.loader || extname(path).slice(1) as Loader,
       })
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -4,7 +4,7 @@ export function resolveOptions(userOptions: UserOptions): ResolvedOptions {
   return {
     format: 'cjs',
     target: 'es2019',
-    sourcemap: true,
+    sourcemap: 'inline',
     ...userOptions,
   }
 }


### PR DESCRIPTION
<!-- Thank you for contributing! -->

### Description
When debugging jest tests written in typescript, the debugger does not stop in breakpoints.
To fix that, we have to include the filename inside the sourcemap as well as inline the map.
<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [X] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [X] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [X] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [] Ideally, include relevant tests that fail without this PR but pass with it.
