### PR TITLE
fix: export UserOptions

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -84,6 +84,10 @@ const createTransformer = (userOptions: UserOptions = {}): Transformer<UserOptio
   }
 }
 
+export {
+  UserOptions,
+}
+
 export default {
   createTransformer,
 }


### PR DESCRIPTION
### Description

Export the type `UserOptions`.

This type should be visible to consumers because it's part of the type of the exported `createTransformer` function.

### Additional context

Without this change it's not possible for Typescript consumers to re-export the return value of `createTransformer`:

```ts
import jestEsbuild from "jest-esbuild";

const transformer = jestEsbuild.createTransformer({
    loader: "ts",
    target: "es2015"
});

export default transformer;
```

Typescript complains: "TS4023: Exported variable transformer has or is using name UserOptions from external module but cannot be named."

---

### What is the purpose of this pull request? <!-- (put an "X" next to an item) -->

- [x] Bug fix
- [ ] New Feature
- [ ] Documentation update
- [ ] Other

### Before submitting the PR, please make sure you do the following

- [x] Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- [x] Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- [ ] Ideally, include relevant tests that fail without this PR but pass with it.
